### PR TITLE
force toolbar to be block

### DIFF
--- a/js/redactor/redactor.css
+++ b/js/redactor/redactor.css
@@ -225,6 +225,7 @@ body .redactor_air {
 	overflow: hidden !important;
 	height: 32px !important;
 	border-bottom: 1px solid #bbb;
+  display: block;
 }
 body .redactor_air .redactor_toolbar {
 	padding-right: 2px !important;


### PR DESCRIPTION
a CSS reset that sets ul's to display inline will break the plugin. This fixes it
