### PR TITLE
handle case when value is not a string

### DIFF
--- a/js/redactor/redactor.js
+++ b/js/redactor/redactor.js
@@ -2935,7 +2935,7 @@ Redactor.prototype = {
 			{
 				$.each(this.opts.uploadFields, $.proxy(function(k,v)
 				{					
-					if (v.indexOf('#') === 0)
+					if (v.indexOf && v.indexOf('#') === 0)
 					{
 						v = $(v).val();
 					}


### PR DESCRIPTION
...

uploadFields: {
      'foo': true,

..

if you pass something like this is breaks the plugin because you are trying to call indexOf on a datatype... which it does not support ... so here is a fix
